### PR TITLE
Set notification expiration timeout from 2 milliseconds to -1

### DIFF
--- a/spotify-notify.py
+++ b/spotify-notify.py
@@ -175,7 +175,7 @@ class SpotifyNotify():
             notifyText,
             [],
             {},
-            2
+            -1
         )
 
     def retrieveCoverImage(self, trackInfo):


### PR DESCRIPTION
This was an issue with xfce4-notifyd as notification daemon. With the expiration timeout set to 2 milliseconds the notification was not visible. Setting it to 5000 for 5 seconds or -1 to respect the daemon default settings worked just fine.
