### PR TITLE
Added more detailed instructions about installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,52 @@
 spotify-notify
 ==============
 
-Spotify-notify is a notifier for currently playing song in Spotify on a linux system, using the notify-osd notifier (found in e.g. Ubuntu). It also includes support for media keys It is intended for use on Ubuntu systems - current dependency is notify-osd.
+Spotify-notify is a __notifier for currently playing song__ in Spotify on a linux system, using the notify-osd notifier (found in e.g. Ubuntu). It also includess __support for media keys__. It is intended for use on Ubuntu systems - current dependency is notify-osd.
 
 ![Example image](https://dl.dropbox.com/u/100344/spotifynotify2.png)
 
 
 Getting started
 ---------------
+### Installation
 
-These instructions apply to Ubuntu only (but may work on other Debian-based distros)
+If you want to install spotify-notify permanently, it's recommended to follow these instructions. They apply to Ubuntu only but may work on other Debian-based distros as well.
 
-To get it running, you first need to clone this repository or download the file from above.
+Just execute the following terminal commands to install spotify-notify:
+```bash
+sudo mkdir /opt/spotify-notify/     # Create new directory to install spotify-notify
+cd /opt/spotify-notify/             # Change current directory to this folder
+# Download current version of spotify-notify
+sudo wget https://raw.githubusercontent.com/sveint/spotify-notify/master/spotify-notify.py
+sudo chmod a+x spotify-notify.py    # Mark spotify-notify.py as an executable
+python spotify-notify.py -s &       # Start spotify-notify in background
+```
+
+### Adding spotify-notify to autostart
+In Ubuntu you can easily add spotify-notify to the autostart. You only need to open the startup-programmes dialog. More details can be found in the [Ubuntu Wiki](https://help.ubuntu.com/community/AddingProgramToSessionStartup#Startup_Programs). As the name you can choose something like "Spotify Notify" and as the command to be executed, choose
+
+`python spotify-notify.py -s`
+
+The comment field can be left empty.
+
+Advanced
+--------
+### Running spotify-notify (general information)
+To get it running, you first need to clone this repository or download the file `spotify-notify.py`. Afterwards you can run spotify-notify by
 
 `python spotify-notify.py`
 
 It will launch Spotify for you if not already running. Please see options below to change default behavior.
 
-If you want to launch the file directly you can first do:
+If you want to launch the file directly you can first add execution rights to it:
 
 `chmod a+x spotify-notify.py`
-then launch by `./spotify-notify.py`
+
+then launch by
+
+`./spotify-notify.py`
+
+### Command line options
 
 Available options are:
 


### PR DESCRIPTION
Added an easier and more complete instruction on how and where to install spotify-notify. It will certainly help beginners with the installation. Also it will be faster for "pros" to install the script as they only have to copy-paste a few terminal commands...
