### PR TITLE
Ported spotify-notify.py to Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ If you want to install spotify-notify permanently, it's recommended to follow th
 
 Just execute the following terminal commands to install spotify-notify:
 ```bash
-sudo mkdir /opt/spotify-notify/     # Create new directory to install spotify-notify
-cd /opt/spotify-notify/             # Change current directory to this folder
+sudo mkdir /opt/spotify-notify/        # Create new directory to install spotify-notify
+cd /opt/spotify-notify/                # Change current directory to this folder
 # Download current version of spotify-notify
 sudo wget https://raw.githubusercontent.com/sveint/spotify-notify/master/spotify-notify.py
-sudo chmod a+x spotify-notify.py    # Mark spotify-notify.py as an executable
-python3 spotify-notify.py -s &       # Start spotify-notify in background
+sudo chmod a+x spotify-notify.py       # Mark spotify-notify.py as an executable
+python3 spotify-notify.py -s & disown  # Start spotify-notify in background
 ```
 
 ### Adding spotify-notify to autostart

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ cd /opt/spotify-notify/             # Change current directory to this folder
 # Download current version of spotify-notify
 sudo wget https://raw.githubusercontent.com/sveint/spotify-notify/master/spotify-notify.py
 sudo chmod a+x spotify-notify.py    # Mark spotify-notify.py as an executable
-python spotify-notify.py -s &       # Start spotify-notify in background
+python3 spotify-notify.py -s &       # Start spotify-notify in background
 ```
 
 ### Adding spotify-notify to autostart
 In Ubuntu you can easily add spotify-notify to the autostart. You only need to open the startup-programmes dialog. More details can be found in the [Ubuntu Wiki](https://help.ubuntu.com/community/AddingProgramToSessionStartup#Startup_Programs). As the name you can choose something like "Spotify Notify" and as the command to be executed, choose
 
-`python spotify-notify.py -s`
+`python3 spotify-notify.py -s`
 
 The comment field can be left empty.
 
@@ -34,7 +34,7 @@ Advanced
 ### Running spotify-notify (general information)
 To get it running, you first need to clone this repository or download the file `spotify-notify.py`. Afterwards you can run spotify-notify by
 
-`python spotify-notify.py`
+`python3 spotify-notify.py`
 
 It will launch Spotify for you if not already running. Please see options below to change default behavior.
 

--- a/spotify-notify.py
+++ b/spotify-notify.py
@@ -12,8 +12,6 @@ from dbus.mainloop.glib import DBusGMainLoop
 import os, tempfile, sys, time, re
 import urllib.request
 from gi.repository import GObject
-#TODO: Check if the following line really is not needed
-#from gi.repository import Gtk
 from optparse import OptionParser
 from subprocess import *
 

--- a/spotify-notify.py
+++ b/spotify-notify.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
  
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
There were some small changes necessary to make this script Python3 compatible. This version of spotify-notify doesn't work with Python2 anymore. However, I hope the changes were small enough to not have added any new bugs. I tested this on Ubuntu 14.04 TLS, where it works great.

The reason for this port is that Python2 is more or less deprecated and Ubuntu is trying to ban Python2 from its default installation. They could not hit this goal in Ubuntu 14.04 LTS but they are certainly going to remove Python2 at some point in the future.

You could consider tagging the old version with 2.0 and this version with 3.0 or whatever. Then one could mention in the README, that version 2.0 is the last version to support python2 and that all newer releases require python3 to work.
