### PR TITLE
Added download of spotify icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ sudo mkdir /opt/spotify-notify/     # Create new directory to install spotify-no
 cd /opt/spotify-notify/             # Change current directory to this folder
 # Download current version of spotify-notify
 sudo wget https://raw.githubusercontent.com/sveint/spotify-notify/master/spotify-notify.py
+# Download spotify logo
+sudo wget https://raw.githubusercontent.com/sveint/spotify-notify/master/icon_spotify.png
 sudo chmod a+x spotify-notify.py    # Mark spotify-notify.py as an executable
 python spotify-notify.py -s &       # Start spotify-notify in background
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 spotify-notify
 ==============
 
-Spotify-notify is a __notifier for currently playing song__ in Spotify on a linux system, using the notify-osd notifier (found in e.g. Ubuntu). It also includess __support for media keys__. It is intended for use on Ubuntu systems - current dependency is notify-osd.
+Spotify-notify is a __notifier for currently playing song__ in Spotify on a linux system, using the notify-osd notifier (found in e.g. Ubuntu). It also includes __support for media keys__. It is intended for use on Ubuntu systems - current dependency is notify-osd.
 
 ![Example image](https://dl.dropbox.com/u/100344/spotifynotify2.png)
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ If you want to install spotify-notify permanently, it's recommended to follow th
 
 Just execute the following terminal commands to install spotify-notify:
 ```bash
-sudo mkdir /opt/spotify-notify/     # Create new directory to install spotify-notify
-cd /opt/spotify-notify/             # Change current directory to this folder
+sudo mkdir /opt/spotify-notify/        # Create new directory to install spotify-notify
+cd /opt/spotify-notify/                # Change current directory to this folder
 # Download current version of spotify-notify
 sudo wget https://raw.githubusercontent.com/sveint/spotify-notify/master/spotify-notify.py
 # Download spotify logo
 sudo wget https://raw.githubusercontent.com/sveint/spotify-notify/master/icon_spotify.png
-sudo chmod a+x spotify-notify.py    # Mark spotify-notify.py as an executable
-python spotify-notify.py -s &       # Start spotify-notify in background
+sudo chmod a+x spotify-notify.py       # Mark spotify-notify.py as an executable
+python spotify-notify.py -s & disown   # Start spotify-notify in background
 ```
 
 ### Adding spotify-notify to autostart


### PR DESCRIPTION
The instruction to download the spotify logo was missing in the previous version. So if no cover image was found, the notification would not display any image.
